### PR TITLE
Allow MACD to use arbitrary periods

### DIFF
--- a/technical-indicators.src.js
+++ b/technical-indicators.src.js
@@ -144,7 +144,8 @@
 	 *
 	 * @param yData : array of y variables.
 	 * @param xData : array of x variables.
-	 * @param periods : The amount of "days" to average from.
+	 * @param periods : An optional array of the MACD periods in the order
+     * [shortPeriod, longPeriod, signalPeriod ]
 	 * @return : An array with 3 arrays. (0 : macd, 1 : signalline , 2 : histogram) 
 	**/
 	function calcMACD (xData, yData, periods) {
@@ -162,13 +163,13 @@
 			histogram = [];
         if (Array.isArray(periods)) {
             if (periods.length >= 1) {
-                shortPeriod = periods[0];
+                shortPeriod = periods[0] || 12;
             }
             if (periods.length >= 2) {
-                longPeriod = periods[1];
+                longPeriod = periods[1] || 26;
             }
             if (periods.length >=3 ) {
-                signalPeriod = periods[2];
+                signalPeriod = periods[2] || 9;
             }
         }
 		// Calculating the short and long EMA used when calculating the MACD

--- a/technical-indicators.src.js
+++ b/technical-indicators.src.js
@@ -160,8 +160,17 @@
 			yMACD = [],
 			signalLine = [],
 			histogram = [];
-
-
+        if (Array.isArray(periods)) {
+            if (periods.length >= 1) {
+                shortPeriod = periods[0];
+            }
+            if (periods.length >= 2) {
+                longPeriod = periods[1];
+            }
+            if (periods.length >=3 ) {
+                signalPeriod = periods[2];
+            }
+        }
 		// Calculating the short and long EMA used when calculating the MACD
 		shortEMA = EMA(xData, yData, shortPeriod);
 		longEMA = EMA(xData, yData, longPeriod);


### PR DESCRIPTION
Hello.
This pull request allows the `periods` argument in the MACD call to be an array with a list of short, long and signal Periods. This allows users to plot MACD with arbitrary periods rather than the fixed `[12, 26, 9]`. It automatically handles defaults.

Thanks.