### PR TITLE
Update arrayAvg to account for null values

### DIFF
--- a/technical-indicators.src.js
+++ b/technical-indicators.src.js
@@ -372,9 +372,9 @@
 	 *
 	**/
 	function arrayAvg (arr) {
-	    var sum = 0,
-	        arrLengthOfNonNullValues = 0,
-	        i = arr.length;
+	    	var sum = 0,
+	        	arrLengthOfNonNullValues = 0,
+	        	i = arr.length;
 	   	        
 		while (i--) {
 			sum = sum + arr[i];

--- a/technical-indicators.src.js
+++ b/technical-indicators.src.js
@@ -372,15 +372,22 @@
 	 *
 	**/
 	function arrayAvg (arr) {
-		var sum = 0,
-			arrLength = arr.length,
-			i = arrLength;
-
+	    var sum = 0,
+	        arrLengthOfNonNullValues = 0,
+	        i = arr.length;
+	   	        
 		while (i--) {
 			sum = sum + arr[i];
 		}
-
-		return (sum / arrLength);
+	    
+        	//count the non-null entries in the array
+		for (var j = 0; j < arr.length; j++) {
+		    if (arr[j] != null) {
+		        arrLengthOfNonNullValues++;
+		    }
+		}
+	    
+		return (sum / arrLengthOfNonNullValues);
 	}
 
 }(Highcharts));


### PR DESCRIPTION
arrayAvg used to not account for null values when calculating the average of the arrays values.  A simple example would be
[null, null, 100, 50, null] .  arrayAvg used to return 30.  Now it returns 75.