### PR TITLE
Update arrayAvg to account for null values

### DIFF
--- a/technical-indicators.src.js
+++ b/technical-indicators.src.js
@@ -373,14 +373,26 @@
 	**/
 	function arrayAvg (arr) {
 		var sum = 0,
-			arrLength = arr.length,
-			i = arrLength;
-
+	        	arrLengthOfNonNullValues = 0,
+			i = arr.length;
+	   	        
 		while (i--) {
 			sum = sum + arr[i];
 		}
-
-		return (sum / arrLength);
+	    
+        	//count the non-null entries in the array
+		for (var j = 0; j < arr.length; j++) {
+		    if (arr[j] != null) {
+		        arrLengthOfNonNullValues++;
+		    }
+		}
+	    
+        	//if they are all null or the array is empty, then return null
+		if (arrLengthOfNonNullValues == 0) {
+		    return null;
+		}
+	    
+		return (sum / arrLengthOfNonNullValues);
 	}
 
 }(Highcharts));


### PR DESCRIPTION
arrayAvg used to not account for null values when calculating the average of the arrays values.  A simple example would be
[null, null, 100, 50, null] .  arrayAvg used to return 30.  Now it returns 75.

Also, will return null if given an empty array or all value of the array are null